### PR TITLE
rm os.environ.clear()

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,8 +26,8 @@ def serve_huggingface_js():
 def serve_chat_widget_js():
     return send_from_directory('../cdn', 'chat-widget.js')
 
-# Clear the environment variables
-os.environ.clear()
+# Clear the environment variables comment this out before checking in
+# os.environ.clear()
 
 # Load dev environment variables
 # load_dotenv(".env.dev")

--- a/backend/qdrant.py
+++ b/backend/qdrant.py
@@ -6,8 +6,8 @@ import PyPDF2
 import traceback
 import os
 
-# Clear the environment variables
-os.environ.clear()
+# Clear the environment variables comment this out before checking in
+# os.environ.clear()
 
 # Load dev environment variables
 # load_dotenv(".env.dev")


### PR DESCRIPTION
os.environ.clear() is clearing the env variables causing the render build to fail. 